### PR TITLE
Fix clippy error for exercise 201

### DIFF
--- a/src/example101.rs
+++ b/src/example101.rs
@@ -23,11 +23,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test3() {
         let e = 1;
         let f = 2;
 
-        assert_eq!(add_two_integers(e, f), 4);
+        assert_ne!(add_two_integers(e, f), 4);
     }
 }

--- a/src/example201.rs
+++ b/src/example201.rs
@@ -1,10 +1,10 @@
-fn double_vector_i32(input: Vec<i32>) -> Vec<i32> {
+fn double_slice_i32(input: &[i32]) -> Vec<i32> {
     let n = input.len();
     let mut result = Vec::with_capacity(2 * n);
 
     // Append the input vector twice
-    result.extend_from_slice(&input);
-    result.extend_from_slice(&input);
+    result.extend_from_slice(input);
+    result.extend_from_slice(input);
 
     result
 }
@@ -16,7 +16,7 @@ mod tests {
     #[test]
     fn test_1() {
         let a = vec![5, 4, 3, 2, 1];
-        let doubled = double_vector_i32(a);
+        let doubled = double_slice_i32(&a);
         assert_eq!(doubled, vec![5, 4, 3, 2, 1, 5, 4, 3, 2, 1]);
     }
 }


### PR DESCRIPTION
Resolve #12
clippy 가 에러 하나 해결하면 다른 에러를 띄우는 경우가 있기 때문에,
이 PR 은 PR #11 에 있는 커밋에 의존하도록 했습니다.